### PR TITLE
Restart ESPHome after upgrade

### DIFF
--- a/roles/ansible_role_esphome/tasks/install_esphome.yml
+++ b/roles/ansible_role_esphome/tasks/install_esphome.yml
@@ -11,6 +11,7 @@
     virtualenv_command: /usr/bin/python3 -m venv
 
 - name: Install defined version of ESPHome in virtual environment
+  notify: Restart ESP Home
   ansible.builtin.pip:
     name: esphome
     version: "{{ esphome_version }}"
@@ -20,6 +21,7 @@
   when: esphome_version is defined
 
 - name: Install latest version of ESPHome in virtual environment
+  notify: Restart ESP Home
   ansible.builtin.pip:
     name: esphome
     virtualenv: "{{ esphome_conf_dir }}"


### PR DESCRIPTION
If the installation of ESPHome results in changes, the service should be restarted to use the new version.